### PR TITLE
Repaint only the regions a change touched, and blit the canvas on pan

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,11 @@
       <input type="checkbox" id="rms-band" />
     </label>
 
+    <label for="waveform"
+      >Waveform
+      <input type="checkbox" id="waveform" />
+    </label>
+
     <label for="paint-regions"
       >Paint regions
       <input type="checkbox" id="paint-regions" />

--- a/demo/index.html
+++ b/demo/index.html
@@ -27,6 +27,11 @@
       <input type="checkbox" id="rms-band" />
     </label>
 
+    <label for="paint-regions"
+      >Paint regions
+      <input type="checkbox" id="paint-regions" />
+    </label>
+
     <canvas id="canvas"></canvas>
     <script type="module" src="./js/index.ts"></script>
   </body>

--- a/demo/js/index.ts
+++ b/demo/js/index.ts
@@ -68,25 +68,17 @@ const waveformCb = document.getElementById("waveform") as HTMLInputElement;
   });
 
   paintRegionsCb.addEventListener("change", () => {
-    const state = waveShaper.getState();
-    state.configuration.showPaintRegions = paintRegionsCb.checked;
-
-    waveShaper.updateState(() => [
-      { ...state, audioData },
-      undefined,
-      undefined,
-    ]);
+    waveShaper.updateState((state) => {
+      state.configuration.showPaintRegions = paintRegionsCb.checked;
+      return [state, undefined, undefined];
+    });
   });
 
   waveformCb.addEventListener("change", () => {
-    const state = waveShaper.getState();
-    state.configuration.showWaveform = waveformCb.checked;
-
-    waveShaper.updateState(() => [
-      { ...state, audioData },
-      undefined,
-      undefined,
-    ]);
+    waveShaper.updateState((state) => {
+      state.configuration.showWaveform = waveformCb.checked;
+      return [state, undefined, undefined];
+    });
   });
 
   (globalThis as any)["WaveShaper"] = waveShaper;

--- a/demo/js/index.ts
+++ b/demo/js/index.ts
@@ -6,6 +6,9 @@ import type { Automation } from "../../src/types";
 const canvas = document.getElementById("canvas") as HTMLCanvasElement;
 const automationCb = document.getElementById("automation") as HTMLInputElement;
 const rmsBandCb = document.getElementById("rms-band") as HTMLInputElement;
+const paintRegionsCb = document.getElementById(
+  "paint-regions"
+) as HTMLInputElement;
 
 (async function main() {
   const dataLoader = new DataLoader();
@@ -24,6 +27,7 @@ const rmsBandCb = document.getElementById("rms-band") as HTMLInputElement;
 
   automationCb.checked = configuration.showAutomation;
   rmsBandCb.checked = configuration.showRmsBand;
+  paintRegionsCb.checked = configuration.showPaintRegions ?? false;
   const audioData = await dataLoader.load(audio, ctx);
 
   const waveShaper = new WaveShaper(canvas, ctx, {
@@ -49,6 +53,17 @@ const rmsBandCb = document.getElementById("rms-band") as HTMLInputElement;
   rmsBandCb.addEventListener("change", () => {
     const state = waveShaper.getState();
     state.configuration.showRmsBand = rmsBandCb.checked;
+
+    waveShaper.updateState(() => [
+      { ...state, audioData },
+      undefined,
+      undefined,
+    ]);
+  });
+
+  paintRegionsCb.addEventListener("change", () => {
+    const state = waveShaper.getState();
+    state.configuration.showPaintRegions = paintRegionsCb.checked;
 
     waveShaper.updateState(() => [
       { ...state, audioData },

--- a/demo/js/index.ts
+++ b/demo/js/index.ts
@@ -1,7 +1,7 @@
 import { WaveShaper } from "../../src";
 import { DataLoader } from "./data-loader";
 import type ApiResponse from "../data/session.json";
-import type { Automation } from "../../src/types";
+import type { Automation, WaveShaperConfig } from "../../src/types";
 
 const canvas = document.getElementById("canvas") as HTMLCanvasElement;
 const automationCb = document.getElementById("automation") as HTMLInputElement;
@@ -26,10 +26,14 @@ const waveformCb = document.getElementById("waveform") as HTMLInputElement;
     res.json()
   );
 
-  automationCb.checked = configuration.showAutomation;
-  rmsBandCb.checked = configuration.showRmsBand;
-  paintRegionsCb.checked = configuration.showPaintRegions ?? false;
-  waveformCb.checked = configuration.showWaveform ?? true;
+  // session.json only carries the required keys; the optional flags live on
+  // the library's config type
+  const config: WaveShaperConfig = configuration;
+
+  automationCb.checked = config.showAutomation;
+  rmsBandCb.checked = config.showRmsBand;
+  paintRegionsCb.checked = config.showPaintRegions ?? false;
+  waveformCb.checked = config.showWaveform ?? true;
   const audioData = await dataLoader.load(audio, ctx);
 
   const waveShaper = new WaveShaper(canvas, ctx, {

--- a/demo/js/index.ts
+++ b/demo/js/index.ts
@@ -9,6 +9,7 @@ const rmsBandCb = document.getElementById("rms-band") as HTMLInputElement;
 const paintRegionsCb = document.getElementById(
   "paint-regions"
 ) as HTMLInputElement;
+const waveformCb = document.getElementById("waveform") as HTMLInputElement;
 
 (async function main() {
   const dataLoader = new DataLoader();
@@ -28,6 +29,7 @@ const paintRegionsCb = document.getElementById(
   automationCb.checked = configuration.showAutomation;
   rmsBandCb.checked = configuration.showRmsBand;
   paintRegionsCb.checked = configuration.showPaintRegions ?? false;
+  waveformCb.checked = configuration.showWaveform ?? true;
   const audioData = await dataLoader.load(audio, ctx);
 
   const waveShaper = new WaveShaper(canvas, ctx, {
@@ -64,6 +66,17 @@ const paintRegionsCb = document.getElementById(
   paintRegionsCb.addEventListener("change", () => {
     const state = waveShaper.getState();
     state.configuration.showPaintRegions = paintRegionsCb.checked;
+
+    waveShaper.updateState(() => [
+      { ...state, audioData },
+      undefined,
+      undefined,
+    ]);
+  });
+
+  waveformCb.addEventListener("change", () => {
+    const state = waveShaper.getState();
+    state.configuration.showWaveform = waveformCb.checked;
 
     waveShaper.updateState(() => [
       { ...state, audioData },

--- a/e2e/audio.test.ts
+++ b/e2e/audio.test.ts
@@ -654,6 +654,43 @@ test.describe("waveform rendering", () => {
     expect(Math.max(...heights) - Math.min(...heights)).toBeLessThanOrEqual(1);
   });
 
+  test("showWaveform off skips waveform work entirely", async ({ page }) => {
+    await loadPage(page);
+    const withWave = await countWavePixels(page);
+    expect(withWave).toBeGreaterThan(100);
+
+    await page.evaluate(() => {
+      const ws = (globalThis as any)["WaveShaper"];
+      ws.updateState((state: any) => {
+        state.configuration.showWaveform = false;
+        return [state, undefined, undefined];
+      });
+      ws.process();
+    });
+
+    // the waveform bodies go; the resize handles and automation lines are
+    // dark too and legitimately stay, so this is a drop, not a zero
+    expect(await countWavePixels(page)).toBeLessThan(withWave / 2);
+
+    // and no summaries are computed or held for hidden waveforms
+    const buckets = await page.evaluate(
+      () => (globalThis as any)["WaveShaper"].getDiagnostics().waveformBuckets
+    );
+    expect(buckets).toBe(0);
+
+    // toggling back on restores the identical rendering
+    await page.evaluate(() => {
+      const ws = (globalThis as any)["WaveShaper"];
+      ws.updateState((state: any) => {
+        state.configuration.showWaveform = true;
+        return [state, undefined, undefined];
+      });
+      ws.process();
+    });
+
+    expect(await countWavePixels(page)).toBe(withWave);
+  });
+
   test("keeps drawing a waveform after a cut", async ({ page }) => {
     const errors: string[] = [];
     page.on("pageerror", (e) => errors.push(e.message));

--- a/e2e/partial-redraw.test.ts
+++ b/e2e/partial-redraw.test.ts
@@ -1,0 +1,145 @@
+import { expect, test } from "@playwright/test";
+import {
+  drag,
+  getModifier,
+  getScales,
+  getState,
+  loadPage,
+  pan,
+} from "./utils";
+
+/**
+ * The canvas is no longer repainted wholesale: a filtered bind repaints only
+ * the regions its renderer reported, and a pan shifts the pixels already on
+ * screen and repaints only the exposed strip. Two properties keep that
+ * honest, and both are pinned here:
+ *
+ * - whatever shortcuts were taken along the way, a settled canvas must be
+ *   indistinguishable from one painted from scratch;
+ * - the shortcuts must actually be taken, which the lastPaintFraction
+ *   diagnostic makes observable.
+ */
+
+/** The canvas, as it is, against the same canvas fully repainted. */
+async function expectSettledEqualsFullRepaint(
+  page: import("@playwright/test").Page
+) {
+  const identical = await page.evaluate(() => {
+    const ws = (globalThis as any)["WaveShaper"];
+    const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+    const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
+
+    const settled = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+
+    ws.invalidate();
+    ws.process();
+
+    const repainted = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
+
+    if (settled.length !== repainted.length) return false;
+    for (let i = 0; i < settled.length; i++) {
+      if (settled[i] !== repainted[i]) return false;
+    }
+    return true;
+  });
+
+  expect(identical).toBe(true);
+}
+
+test("a settled drag leaves exactly what a full repaint would", async ({
+  page,
+}) => {
+  await loadPage(page);
+  const { xScale } = await getScales(page);
+
+  await drag(
+    page,
+    { track: "1", time: xScale.invert(5) },
+    { track: "2", time: xScale.invert(400) }
+  );
+
+  await expectSettledEqualsFullRepaint(page);
+});
+
+test("a settled pan leaves exactly what a full repaint would", async ({
+  page,
+}) => {
+  await loadPage(page);
+  const { xScale } = await getScales(page);
+
+  await pan(
+    page,
+    { track: "1", time: xScale.invert(600) },
+    { track: "1", time: xScale.invert(113) }
+  );
+  // the gesture's end refine has to land before the comparison
+  await page.waitForTimeout(150);
+
+  await expectSettledEqualsFullRepaint(page);
+});
+
+test("dragging an interval repaints only its own region", async ({ page }) => {
+  await loadPage(page);
+  const { xScale } = await getScales(page);
+  const state = await getState(page);
+  const interval = state.intervals[0];
+
+  await drag(
+    page,
+    { track: interval.track, time: xScale.invert(60) },
+    { track: interval.track, time: xScale.invert(200) }
+  );
+
+  // the fraction of the final mid-drag paint: the interval plus its slop,
+  // nowhere near the whole canvas
+  const fraction = await page.evaluate(
+    () => (globalThis as any)["WaveShaper"].getDiagnostics().lastPaintFraction
+  );
+
+  expect(fraction).toBeGreaterThan(0);
+  expect(fraction).toBeLessThan(0.5);
+});
+
+test("panning repaints only the exposed strip", async ({ page }) => {
+  await loadPage(page);
+
+  const modifier = await getModifier(page);
+  const box = (await (await page.$("canvas"))!.boundingBox())!;
+
+  await page.keyboard.down(modifier);
+  await page.mouse.move(box.x + 700, box.y + 100);
+  await page.mouse.down();
+
+  // read the fraction mid-gesture, after a small step, before mouseup: the
+  // end refine is deliberately a full pass and would overwrite it
+  await page.mouse.move(box.x + 680, box.y + 100, { steps: 1 });
+  await page.waitForTimeout(100);
+
+  const fraction = await page.evaluate(
+    () => (globalThis as any)["WaveShaper"].getDiagnostics().lastPaintFraction
+  );
+
+  await page.mouse.up();
+  await page.keyboard.up(modifier);
+
+  expect(fraction).toBeGreaterThan(0);
+  expect(fraction).toBeLessThan(0.1);
+});
+
+test("the gesture-end refine repaints everything", async ({ page }) => {
+  await loadPage(page);
+  const { xScale } = await getScales(page);
+
+  await pan(
+    page,
+    { track: "1", time: xScale.invert(500) },
+    { track: "1", time: xScale.invert(300) }
+  );
+  await page.waitForTimeout(150);
+
+  const fraction = await page.evaluate(
+    () => (globalThis as any)["WaveShaper"].getDiagnostics().lastPaintFraction
+  );
+
+  expect(fraction).toBe(1);
+});

--- a/e2e/partial-redraw.test.ts
+++ b/e2e/partial-redraw.test.ts
@@ -143,3 +143,72 @@ test("the gesture-end refine repaints everything", async ({ page }) => {
 
   expect(fraction).toBe(1);
 });
+
+test("showPaintRegions tints exactly the repainted region", async ({
+  page,
+}) => {
+  await loadPage(page);
+  const { xScale } = await getScales(page);
+
+  const countOverlay = () =>
+    page.evaluate(() => {
+      const canvas = document.querySelector("canvas") as HTMLCanvasElement;
+      const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
+      const { data, width } = ctx.getImageData(
+        0,
+        0,
+        canvas.width,
+        canvas.height
+      );
+
+      // the overlay border is filled opaque magenta so it reads back exactly
+      let inLeftHalf = 0;
+      let inRightThird = 0;
+      for (let i = 0; i < data.length; i += 4) {
+        if (data[i] === 255 && data[i + 1] === 0 && data[i + 2] === 255) {
+          const x = (i / 4) % width;
+          if (x < width / 2) inLeftHalf++;
+          if (x > (width * 2) / 3) inRightThird++;
+        }
+      }
+      return { inLeftHalf, inRightThird };
+    });
+
+  await page.evaluate(() => {
+    const ws = (globalThis as any)["WaveShaper"];
+    ws.updateState((state: any) => {
+      state.configuration.showPaintRegions = true;
+      // confine the flash subject to the left half of the view
+      state.intervals = state.intervals.filter((i: any) => i.id === "1");
+      state.intervals[0].end = 5000;
+      return [state, undefined, undefined];
+    });
+    ws.process();
+  });
+
+  // drag the clip within the left half: the tint must cover its region and
+  // stay out of the untouched right third
+  await drag(
+    page,
+    { track: "1", time: xScale.invert(100) },
+    { track: "1", time: xScale.invert(160) }
+  );
+
+  const flashed = await countOverlay();
+  expect(flashed.inLeftHalf).toBeGreaterThan(0);
+  expect(flashed.inRightThird).toBe(0);
+
+  // turning the flag off leaves no trace of the overlay
+  await page.evaluate(() => {
+    const ws = (globalThis as any)["WaveShaper"];
+    ws.updateState((state: any) => {
+      state.configuration.showPaintRegions = false;
+      return [state, undefined, undefined];
+    });
+    ws.process();
+  });
+
+  const cleared = await countOverlay();
+  expect(cleared.inLeftHalf).toBe(0);
+  expect(cleared.inRightThird).toBe(0);
+});

--- a/e2e/partial-redraw.test.ts
+++ b/e2e/partial-redraw.test.ts
@@ -294,3 +294,39 @@ test("moving the automation hover marker never strands it", async ({
 
   await expectSettledEqualsFullRepaint(page);
 });
+
+test("dragging an automation point repaints only its track's band", async ({
+  page,
+}) => {
+  await loadPage(page);
+
+  await page.evaluate(() => {
+    const ws = (globalThis as any)["WaveShaper"];
+    ws.updateState((state: any) => {
+      state.configuration.showAutomation = true;
+      return [state, undefined, undefined];
+    });
+    ws.process();
+  });
+
+  // locate the second point of track 1's lane (time 1000, value 0.5)
+  const { xScale, yScale } = await getScales(page);
+  const box = (await (await page.$("canvas"))!.boundingBox())!;
+  const pointX = box.x + xScale(1000);
+  const pointY = box.y + (yScale("1") ?? 0) + 0.5 * yScale.bandwidth();
+
+  await page.mouse.move(pointX, pointY);
+  await page.mouse.down();
+  await page.mouse.move(pointX - 80, pointY + 15, { steps: 4 });
+  await page.mouse.up();
+
+  // the last drag tick's paint: one track band, nowhere near the canvas
+  const fraction = await page.evaluate(
+    () => (globalThis as any)["WaveShaper"].getDiagnostics().lastPaintFraction
+  );
+
+  expect(fraction).toBeGreaterThan(0);
+  expect(fraction).toBeLessThan(0.5);
+
+  await expectSettledEqualsFullRepaint(page);
+});

--- a/e2e/partial-redraw.test.ts
+++ b/e2e/partial-redraw.test.ts
@@ -15,16 +15,27 @@ import {
  * honest, and both are pinned here:
  *
  * - whatever shortcuts were taken along the way, a settled canvas must be
- *   indistinguishable from one painted from scratch;
+ *   indistinguishable from one painted from scratch (up to the bounded
+ *   antialiasing noise clipped rasterization introduces - see the helper);
  * - the shortcuts must actually be taken, which the lastPaintFraction
  *   diagnostic makes observable.
  */
 
-/** The canvas, as it is, against the same canvas fully repainted. */
+/**
+ * The canvas, as it is, against the same canvas fully repainted.
+ *
+ * Not a bit-exact comparison: Chromium rasterizes a fill slightly
+ * differently when a clip cuts through its path, so pixels painted under a
+ * partial repaint's clip can sit a few antialiasing units away from a
+ * from-scratch render - deterministic (repainting the same region twice is
+ * bit-identical) and far below visible. The bounds are tight enough that
+ * any real staleness still fails loudly: a stranded hover marker or a
+ * missed strip is hundreds of contiguous pixels at full-contrast deltas.
+ */
 async function expectSettledEqualsFullRepaint(
   page: import("@playwright/test").Page
 ) {
-  const identical = await page.evaluate(() => {
+  const result = await page.evaluate(() => {
     const ws = (globalThis as any)["WaveShaper"];
     const canvas = document.querySelector("canvas") as HTMLCanvasElement;
     const ctx = canvas.getContext("2d", { willReadFrequently: true })!;
@@ -36,14 +47,21 @@ async function expectSettledEqualsFullRepaint(
 
     const repainted = ctx.getImageData(0, 0, canvas.width, canvas.height).data;
 
-    if (settled.length !== repainted.length) return false;
+    let subpixelDiffs = 0;
+    let maxDelta = 0;
     for (let i = 0; i < settled.length; i++) {
-      if (settled[i] !== repainted[i]) return false;
+      const delta = Math.abs(settled[i] - repainted[i]);
+      if (delta > 0) {
+        subpixelDiffs++;
+        if (delta > maxDelta) maxDelta = delta;
+      }
     }
-    return true;
+
+    return { subpixelDiffs, total: settled.length, maxDelta };
   });
 
-  expect(identical).toBe(true);
+  expect(result.maxDelta).toBeLessThanOrEqual(16);
+  expect(result.subpixelDiffs).toBeLessThanOrEqual(result.total / 1000);
 }
 
 test("a settled drag leaves exactly what a full repaint would", async ({
@@ -211,4 +229,68 @@ test("showPaintRegions tints exactly the repainted region", async ({
   const cleared = await countOverlay();
   expect(cleared.inLeftHalf).toBe(0);
   expect(cleared.inRightThird).toBe(0);
+});
+
+test("sub-pixel pan deltas accumulate instead of freezing the canvas", async ({
+  page,
+}) => {
+  // Precision trackpads pan in fractions of a pixel per event. Each blit
+  // moves whole device pixels, so the remainder must carry across ticks -
+  // discarding it left the canvas frozen for the entire gesture.
+  await loadPage(page);
+
+  const modifier = await getModifier(page);
+  const box = (await (await page.$("canvas"))!.boundingBox())!;
+
+  const snapshot = () =>
+    page.evaluate(() =>
+      (document.querySelector("canvas") as HTMLCanvasElement).toDataURL()
+    );
+
+  const before = await snapshot();
+
+  await page.keyboard.down(modifier);
+  await page.mouse.move(box.x + 600, box.y + 100);
+  await page.mouse.down();
+  for (let i = 1; i <= 30; i++) {
+    await page.mouse.move(box.x + 600 - i * 0.6, box.y + 100, { steps: 1 });
+    await page.waitForTimeout(10);
+  }
+
+  // still mid-gesture: ~18px of pan must be visible on screen already
+  const during = await snapshot();
+
+  await page.mouse.up();
+  await page.keyboard.up(modifier);
+
+  expect(during).not.toBe(before);
+});
+
+test("moving the automation hover marker never strands it", async ({
+  page,
+}) => {
+  // The marker is baked into the draw buffer; under partial repaints a
+  // hover change must repaint where it was and where it lands, or a stale
+  // marker survives every later partial paint.
+  await loadPage(page);
+
+  await page.evaluate(() => {
+    const ws = (globalThis as any)["WaveShaper"];
+    ws.updateState((state: any) => {
+      state.configuration.showAutomation = true;
+      return [state, undefined, undefined];
+    });
+    ws.process();
+  });
+
+  const box = (await (await page.$("canvas"))!.boundingBox())!;
+
+  // two hovers over the automation lane: the marker must move, leaving
+  // nothing at the first position
+  await page.mouse.move(box.x + 200, box.y + 100);
+  await page.waitForTimeout(50);
+  await page.mouse.move(box.x + 420, box.y + 100);
+  await page.waitForTimeout(50);
+
+  await expectSettledEqualsFullRepaint(page);
 });

--- a/src/WaveShaper.ts
+++ b/src/WaveShaper.ts
@@ -634,7 +634,13 @@ export class WaveShaper {
     }
   }
 
-  /** Handed to renderers so they can report regions during a bind. */
+  /**
+   * Handed to renderers so they can report regions whose pixels they
+   * changed. During a bind the reports feed that bind's invalidation
+   * decision; outside one - a hover moving, an async result landing - they
+   * take effect on the dirty region directly, so a report is never
+   * silently dropped.
+   */
   #reportDirty = (
     x0: number,
     y0: number,
@@ -642,7 +648,13 @@ export class WaveShaper {
     y1: number,
     hitPixels = true
   ) => {
-    this.#bindReports?.push({ rect: { x0, y0, x1, y1 }, hitPixels });
+    if (this.#bindReports !== null) {
+      this.#bindReports.push({ rect: { x0, y0, x1, y1 }, hitPixels });
+      return;
+    }
+
+    this.#unionRegion({ x0, y0, x1, y1 });
+    if (hitPixels) this.#hiddenDirty = true;
   };
 
   /**

--- a/src/WaveShaper.ts
+++ b/src/WaveShaper.ts
@@ -18,6 +18,7 @@ import type {
   Renderer,
   WaveShaperState,
   ZoomFn,
+  DirtyRect,
   SelectFn,
 } from "./types";
 import { CursorRenderer } from "./renderers/cursor";
@@ -35,12 +36,24 @@ export class WaveShaper {
 
   /**
    * Nothing in the scene animates on its own, so the render loop only paints
-   * when something has actually changed. Every mutation ends in a "bind"
-   * emit, which is where these get raised; the selection rectangle is the one
-   * exception and marks itself.
+   * when something has actually changed - and only where. The dirty region
+   * accumulates in CSS pixels until the next paint consumes it; null means
+   * clean. Every mutation ends in a "bind" emit, which is where it gets
+   * raised: to the whole render area by default, or to just the regions the
+   * responsible renderer reported for a type-filtered bind. The selection
+   * rectangle is the one exception and marks itself.
    */
-  #dirty = true;
+  #dirtyRegion: DirtyRect | null = null;
   #hiddenDirty = true;
+
+  /**
+   * Regions reported by renderers during the bind currently being emitted;
+   * null outside one. See #emitBind.
+   */
+  #bindReports: DirtyRect[] | null = null;
+
+  /** Last zoom transform seen, for recognising pure-translation gestures. */
+  #lastTransform: { k: number; x: number } | null = null;
 
   /** Whichever modifier the configuration resolves to right now. */
   get modifierKey() {
@@ -57,7 +70,7 @@ export class WaveShaper {
 
       this.#onDrag.forEach((fn) => {
         const bindData = fn(e, this.#dragData, this.#xScale, this.#yScale);
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
     })
     .on("start.drag", (e: d3.D3DragEvent<any, any, any>) => {
@@ -66,7 +79,7 @@ export class WaveShaper {
 
       this.#onDragStart.forEach((fn) => {
         const bindData = fn(e, this.#dragData, this.#xScale, this.#yScale);
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
     })
     .on("end.drag", (e: d3.D3DragEvent<any, any, any>) => {
@@ -74,7 +87,7 @@ export class WaveShaper {
 
       this.#onDragEnd.forEach((fn) => {
         const bindData = fn(e, this.#dragData, this.#xScale, this.#yScale);
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
 
       this.#dragData = null;
@@ -93,7 +106,7 @@ export class WaveShaper {
           this.#xScale,
           this.#yScale
         );
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
     })
     .on("start.select", (e: d3.D3DragEvent<any, any, any>) => {
@@ -112,7 +125,7 @@ export class WaveShaper {
           this.#yScale
         );
 
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
     })
     .on("end.select", (e: d3.D3DragEvent<any, any, any>) => {
@@ -126,7 +139,7 @@ export class WaveShaper {
           this.#xScale,
           this.#yScale
         );
-        bindData && this.#ee.emit("bind", bindData);
+        bindData && this.#emitBind(bindData);
       });
 
       this.#selectionStart = null;
@@ -155,11 +168,32 @@ export class WaveShaper {
       [0, 0],
       [Infinity, Infinity],
     ])
+    // Seed the transform tracker as the gesture begins, so its very first
+    // tick can already tell a pure translation from a zoom.
+    .on("start", (e: d3.D3ZoomEvent<any, any>) => {
+      this.#lastTransform = { k: e.transform.k, x: e.transform.x };
+    })
     .on("zoom", (e: d3.D3ZoomEvent<any, any>) => {
+      const previous = this.#lastTransform;
+      this.#lastTransform = { k: e.transform.k, x: e.transform.x };
+
       this.#xScale = e.transform.rescaleX(this.#xScaleOriginal);
 
       this.#onZoom.forEach((fn) => fn(e));
-      this.#ee.emit("bind");
+
+      // A gesture that only translates moves every pixel already on screen:
+      // shift them and repaint just the strip the shift exposed. Zooming
+      // changes what every pixel means, so it keeps the full repaint.
+      const translation =
+        e.sourceEvent != null &&
+        previous !== null &&
+        e.transform.k === previous.k;
+
+      if (translation && this.#panShift(e.transform.x - previous.x)) {
+        this.#emitBind(undefined, true);
+      } else {
+        this.#emitBind();
+      }
     })
     // Fires when the gesture settles - mouseup, touchend, or the wheel going
     // idle. Renderers that degrade quality while the view is in motion use
@@ -172,7 +206,7 @@ export class WaveShaper {
       if (e.sourceEvent == null) return;
 
       this.#onZoom.forEach((fn) => fn(e));
-      this.#ee.emit("bind");
+      this.#emitBind();
     });
 
   #selecting = false;
@@ -190,10 +224,13 @@ export class WaveShaper {
 
   #hiddenCanvas!: OffscreenCanvas;
   #hiddenCanvasDraw!: OffscreenCanvas;
+  /** Spare buffer the pan fast path shifts into, then swaps with the draw buffer. */
+  #scratchCanvas!: OffscreenCanvas;
 
   // canvas contexts
   #ctxHidden!: OffscreenCanvasRenderingContext2D;
   #ctxHiddenDraw!: OffscreenCanvasRenderingContext2D;
+  #ctxScratch!: OffscreenCanvasRenderingContext2D;
   #ctx!: CanvasRenderingContext2D;
 
   #typeRoots = new Map<symbol, d3.Selection<HTMLElement, any, any, any>>();
@@ -230,8 +267,9 @@ export class WaveShaper {
       signal: this.#abort.signal,
     });
 
-    // every path that changes what is on screen ends up emitting this
-    this.#ee.on("bind", () => this.invalidate());
+    // Every path that changes what is on screen ends up going through
+    // #emitBind, which raises the dirty region - there is deliberately no
+    // listener here, so a bind can dirty less than the whole area.
 
     const config = state.configuration;
     this.#yScale = d3
@@ -262,7 +300,7 @@ export class WaveShaper {
 
         this.#onClick.forEach((fn) => {
           const bindData = fn(e, target, this.#xScale, this.#yScale);
-          bindData && this.#ee.emit("bind", bindData);
+          bindData && this.#emitBind(bindData);
         });
       })
       .on("mousemove", (e) => {
@@ -270,7 +308,7 @@ export class WaveShaper {
 
         this.#onMouseOver.forEach((fn) => {
           const bindData = fn(e, target, this.#xScale, this.#yScale);
-          bindData && this.#ee.emit("bind", bindData);
+          bindData && this.#emitBind(bindData);
         });
       });
 
@@ -281,7 +319,8 @@ export class WaveShaper {
         this.updateState.bind(this),
         this.#hasModifier,
         () => this.#dpr,
-        this.autoContext.sampleRate
+        this.autoContext.sampleRate,
+        this.#reportDirty
       )
     );
 
@@ -336,6 +375,7 @@ export class WaveShaper {
       boundElements: this.#bindMap.size,
       running: this.#raf !== null,
       pixelRatio: this.#dpr,
+      lastPaintFraction: this.#lastPaintFraction,
       ...fromRenderers,
     };
   }
@@ -376,7 +416,7 @@ export class WaveShaper {
     this.state = state;
     initialize && this.#resizeCanvases();
 
-    this.#ee.emit("bind", bindData);
+    this.#emitBind(bindData);
 
     cb?.();
 
@@ -434,7 +474,7 @@ export class WaveShaper {
         register.onBind!(root, this.state, this.#xScale, this.#yScale);
       });
 
-      this.#ee.on("render", (toHidden = false) => {
+      this.#ee.on("render", (toHidden = false, clip?: DirtyRect) => {
         const rootSelection = this.#typeRoots.get(register.TYPE);
 
         if (rootSelection == null) {
@@ -454,7 +494,8 @@ export class WaveShaper {
             toHidden,
             this.#xScale,
             this.#yScale,
-            this.state
+            this.state,
+            clip
           );
         } finally {
           context.restore();
@@ -506,28 +547,193 @@ export class WaveShaper {
   }
 
   process() {
-    this.#ee.emit("bind");
+    this.#emitBind();
     this.redrawHidden();
     this.redraw();
   }
 
-  /** Ask for a repaint on the next frame. */
+  /** Ask for a full repaint on the next frame. */
   invalidate() {
-    this.#dirty = true;
+    const { width, height } = this.state.configuration;
+    this.#dirtyRegion = { x0: 0, y0: 0, x1: width, y1: height };
     this.#hiddenDirty = true;
   }
 
-  redraw() {
-    this.#dirty = false;
+  /**
+   * Ask for a repaint of one region on the next frame. Regions accumulate
+   * into their bounding box until the paint consumes them.
+   */
+  invalidateRect(rect: DirtyRect) {
+    const region = this.#dirtyRegion;
 
-    // The offscreen contexts are scaled, so they clear in CSS pixels; the
-    // visible one is not, and clears its backing store directly.
+    this.#dirtyRegion =
+      region === null
+        ? { ...rect }
+        : {
+            x0: Math.min(region.x0, rect.x0),
+            y0: Math.min(region.y0, rect.y0),
+            x1: Math.max(region.x1, rect.x1),
+            y1: Math.max(region.y1, rect.y1),
+          };
+
+    this.#hiddenDirty = true;
+  }
+
+  /**
+   * Runs a bind and decides what it dirtied. A type-filtered bind whose
+   * renderer reported every region it changed repaints only those regions;
+   * anything else - an unfiltered bind, or a renderer that reports nothing -
+   * falls back to repainting the whole render area, so a renderer that has
+   * never heard of reporting cannot end up under-painted.
+   *
+   * `silent` skips the invalidation decision entirely, for callers that
+   * already marked what changed - the pan fast path, which dirties only the
+   * strip its blit exposed.
+   */
+  #emitBind(data?: BindData, silent = false) {
+    const reports: DirtyRect[] = [];
+
+    // updateState can run inside a bind handler and emit its own bind, so
+    // the collector nests instead of clobbering the outer one.
+    const previous = this.#bindReports;
+    this.#bindReports = reports;
+
+    try {
+      this.#ee.emit("bind", data);
+    } finally {
+      this.#bindReports = previous;
+    }
+
+    if (silent) return;
+
+    if (data?.type !== undefined && reports.length > 0) {
+      for (const rect of reports) this.invalidateRect(rect);
+    } else {
+      this.invalidate();
+    }
+  }
+
+  /** Handed to renderers so they can report regions during a bind. */
+  #reportDirty = (x0: number, y0: number, x1: number, y1: number) => {
+    this.#bindReports?.push({ x0, y0, x1, y1 });
+  };
+
+  /**
+   * Shift the draw buffer sideways by a pan delta and dirty only the strip
+   * the shift exposed. The shift is a whole number of device pixels - the
+   * same trick the audio summaries use, one level up - so the copy is exact;
+   * the sub-pixel remainder is at most half a device pixel of placement
+   * error, and the full repaint on the gesture's end heals it.
+   *
+   * Returns false when the delta is too small to move a whole device pixel
+   * (nothing to do - the caller must not repaint, or the sub-pixel move
+   * would be paid at full price) or so large nothing survives the shift, in
+   * which case a full repaint is the same work and simpler.
+   */
+  #panShift(deltaCss: number): boolean {
+    const { width, height } = this.state.configuration;
+    const deltaDevice = Math.round(deltaCss * this.#dpr);
+
+    if (deltaDevice === 0) return true;
+    if (Math.abs(deltaDevice) >= this.#width) return false;
+
+    // Copy shifted into the spare buffer, then swap the pair - one copy
+    // instead of copy-out-and-back, and no reliance on overlapping
+    // self-drawImage behaviour.
+    this.#ctxScratch.save();
+    this.#ctxScratch.setTransform(1, 0, 0, 1, 0, 0);
+    this.#ctxScratch.clearRect(0, 0, this.#width, this.#height);
+    this.#ctxScratch.drawImage(this.#hiddenCanvasDraw, deltaDevice, 0);
+    this.#ctxScratch.restore();
+
+    [this.#hiddenCanvasDraw, this.#scratchCanvas] = [
+      this.#scratchCanvas,
+      this.#hiddenCanvasDraw,
+    ];
+    [this.#ctxHiddenDraw, this.#ctxScratch] = [
+      this.#ctxScratch,
+      this.#ctxHiddenDraw,
+    ];
+
+    const deltaShifted = deltaDevice / this.#dpr;
+
+    // A region already waiting to be painted describes pixels that just
+    // moved with the shift - carry it along, or two pans inside one frame
+    // leave the first tick's exposed strip stranded at its old coordinates.
+    if (this.#dirtyRegion !== null) {
+      this.#dirtyRegion.x0 += deltaShifted;
+      this.#dirtyRegion.x1 += deltaShifted;
+    }
+
+    if (deltaShifted > 0) {
+      this.invalidateRect({ x0: 0, y0: 0, x1: deltaShifted, y1: height });
+    } else {
+      this.invalidateRect({
+        x0: width + deltaShifted,
+        y0: 0,
+        x1: width,
+        y1: height,
+      });
+    }
+
+    return true;
+  }
+
+  /**
+   * Fraction of the render area the last paint actually repainted, 0..1.
+   * Partial redraws are the whole point of region tracking, so this is the
+   * number to watch: a drag should score far below 1, a zoom exactly 1.
+   */
+  #lastPaintFraction = 1;
+
+  redraw() {
+    const region = this.#dirtyRegion ?? {
+      x0: 0,
+      y0: 0,
+      x1: this.state.configuration.width,
+      y1: this.state.configuration.height,
+    };
+    this.#dirtyRegion = null;
+
     const { width, height } = this.state.configuration;
 
-    this.#ctxHiddenDraw.clearRect(0, 0, width, height);
-    this.#ctx.clearRect(0, 0, this.#width, this.#height);
+    // Snap the region outward to whole device pixels so the clear, the clip
+    // and the final blit all cut on the same texel boundaries.
+    const x0 = Math.max(0, Math.floor(region.x0 * this.#dpr) / this.#dpr);
+    const y0 = Math.max(0, Math.floor(region.y0 * this.#dpr) / this.#dpr);
+    const x1 = Math.min(width, Math.ceil(region.x1 * this.#dpr) / this.#dpr);
+    const y1 = Math.min(height, Math.ceil(region.y1 * this.#dpr) / this.#dpr);
 
-    this.#ee.emit("render");
+    const partial = x0 > 0 || y0 > 0 || x1 < width || y1 < height;
+
+    this.#lastPaintFraction =
+      x1 > x0 && y1 > y0
+        ? ((x1 - x0) * (y1 - y0)) / (width * height)
+        : 0;
+
+    if (x1 > x0 && y1 > y0) {
+      // The offscreen context is scaled, so it clears in CSS pixels. Only
+      // the dirty region is cleared and repainted; everything outside keeps
+      // the pixels it already has.
+      this.#ctxHiddenDraw.save();
+      this.#ctxHiddenDraw.clearRect(x0, y0, x1 - x0, y1 - y0);
+
+      let clip: DirtyRect | undefined;
+      if (partial) {
+        const path = new Path2D();
+        path.rect(x0, y0, x1 - x0, y1 - y0);
+        this.#ctxHiddenDraw.clip(path);
+        clip = { x0, y0, x1, y1 };
+      }
+
+      this.#ee.emit("render", false, clip);
+      this.#ctxHiddenDraw.restore();
+    }
+
+    // The visible canvas always receives the full buffer: after a pan blit
+    // every pixel of it has moved, and a full-surface copy is one drawImage
+    // either way. The visible context is unscaled and works in device pixels.
+    this.#ctx.clearRect(0, 0, this.#width, this.#height);
     this.#ctx.drawImage(this.#hiddenCanvasDraw, 0, 0);
   }
 
@@ -549,7 +755,7 @@ export class WaveShaper {
     const tick = () => {
       // the tick still happens every frame, so a missed invalidate shows up as
       // one late frame rather than a permanently stale canvas
-      if (this.#dirty) this.redraw();
+      if (this.#dirtyRegion !== null) this.redraw();
       this.#raf = requestAnimationFrame(tick);
     };
 
@@ -636,7 +842,7 @@ export class WaveShaper {
 
     d3.select(this.canvas).call(this.#zoom.transform, d3.zoomIdentity);
 
-    this.#ee.emit("bind");
+    this.#emitBind();
   }
 
   /**
@@ -665,16 +871,21 @@ export class WaveShaper {
 
     this.#hiddenCanvas = new OffscreenCanvas(this.#width, this.#height);
     this.#hiddenCanvasDraw = new OffscreenCanvas(this.#width, this.#height);
+    this.#scratchCanvas = new OffscreenCanvas(this.#width, this.#height);
 
     // The visible context is only ever used to clear and to blit a buffer of
     // exactly this size, so it stays in device pixels and copies 1:1.
     this.#ctx = this.canvas.getContext("2d")!;
     this.#ctxHiddenDraw = this.#hiddenCanvasDraw.getContext("2d")!;
+    this.#ctxScratch = this.#scratchCanvas.getContext("2d")!;
     this.#ctxHidden = this.#hiddenCanvas.getContext("2d", {
       willReadFrequently: true,
     })!;
 
+    // The scratch buffer gets the same scale as the draw buffer, because the
+    // pan fast path swaps the two and renderers keep working in CSS pixels.
     this.#ctxHiddenDraw.scale(dpr, dpr);
+    this.#ctxScratch.scale(dpr, dpr);
     this.#ctxHidden.scale(dpr, dpr);
 
     this.invalidate();

--- a/src/WaveShaper.ts
+++ b/src/WaveShaper.ts
@@ -735,6 +735,28 @@ export class WaveShaper {
     // either way. The visible context is unscaled and works in device pixels.
     this.#ctx.clearRect(0, 0, this.#width, this.#height);
     this.#ctx.drawImage(this.#hiddenCanvasDraw, 0, 0);
+
+    // Drawn after the blit and only onto the visible canvas, so the overlay
+    // never reaches the buffer that pan blits shift around; the next paint's
+    // blit wipes it. It survives until then, which reads better than a
+    // one-frame flash under paint-on-change.
+    if (this.state.configuration.showPaintRegions && x1 > x0 && y1 > y0) {
+      const dx = Math.round(x0 * this.#dpr);
+      const dy = Math.round(y0 * this.#dpr);
+      const dw = Math.round((x1 - x0) * this.#dpr);
+      const dh = Math.round((y1 - y0) * this.#dpr);
+      const edge = Math.max(1, Math.round(this.#dpr));
+
+      this.#ctx.fillStyle = "rgba(255, 0, 255, 0.15)";
+      this.#ctx.fillRect(dx, dy, dw, dh);
+
+      // an opaque border, as filled rects so its color reads back exactly
+      this.#ctx.fillStyle = "rgb(255, 0, 255)";
+      this.#ctx.fillRect(dx, dy, dw, edge);
+      this.#ctx.fillRect(dx, dy + dh - edge, dw, edge);
+      this.#ctx.fillRect(dx, dy, edge, dh);
+      this.#ctx.fillRect(dx + dw - edge, dy, edge, dh);
+    }
   }
 
   redrawHidden() {

--- a/src/WaveShaper.ts
+++ b/src/WaveShaper.ts
@@ -50,10 +50,19 @@ export class WaveShaper {
    * Regions reported by renderers during the bind currently being emitted;
    * null outside one. See #emitBind.
    */
-  #bindReports: DirtyRect[] | null = null;
+  #bindReports: Array<{ rect: DirtyRect; hitPixels: boolean }> | null = null;
 
   /** Last zoom transform seen, for recognising pure-translation gestures. */
   #lastTransform: { k: number; x: number } | null = null;
+
+  /**
+   * Pan distance the blits have not yet shown, in CSS pixels. Shifts move by
+   * whole device pixels, so each tick leaves a sub-pixel remainder; carrying
+   * it forward keeps the shifted canvas within half a device pixel of the
+   * true view no matter how many fractional deltas arrive, where discarding
+   * it froze the canvas outright on devices that pan in sub-pixel steps.
+   */
+  #panResidual = 0;
 
   /** Whichever modifier the configuration resolves to right now. */
   get modifierKey() {
@@ -172,6 +181,7 @@ export class WaveShaper {
     // tick can already tell a pure translation from a zoom.
     .on("start", (e: d3.D3ZoomEvent<any, any>) => {
       this.#lastTransform = { k: e.transform.k, x: e.transform.x };
+      this.#panResidual = 0;
     })
     .on("zoom", (e: d3.D3ZoomEvent<any, any>) => {
       const previous = this.#lastTransform;
@@ -192,6 +202,8 @@ export class WaveShaper {
       if (translation && this.#panShift(e.transform.x - previous.x)) {
         this.#emitBind(undefined, true);
       } else {
+        // a full repaint draws the true view, absorbing any pan remainder
+        this.#panResidual = 0;
         this.#emitBind();
       }
     })
@@ -331,7 +343,8 @@ export class WaveShaper {
         this.bindData.bind(this),
         this.releaseBindData.bind(this),
         this.updateState.bind(this),
-        this.#hasModifier
+        this.#hasModifier,
+        this.#reportDirty
       )
     );
 
@@ -564,6 +577,11 @@ export class WaveShaper {
    * into their bounding box until the paint consumes them.
    */
   invalidateRect(rect: DirtyRect) {
+    this.#unionRegion(rect);
+    this.#hiddenDirty = true;
+  }
+
+  #unionRegion(rect: DirtyRect) {
     const region = this.#dirtyRegion;
 
     this.#dirtyRegion =
@@ -575,8 +593,6 @@ export class WaveShaper {
             x1: Math.max(region.x1, rect.x1),
             y1: Math.max(region.y1, rect.y1),
           };
-
-    this.#hiddenDirty = true;
   }
 
   /**
@@ -591,7 +607,7 @@ export class WaveShaper {
    * strip its blit exposed.
    */
   #emitBind(data?: BindData, silent = false) {
-    const reports: DirtyRect[] = [];
+    const reports: Array<{ rect: DirtyRect; hitPixels: boolean }> = [];
 
     // updateState can run inside a bind handler and emit its own bind, so
     // the collector nests instead of clobbering the outer one.
@@ -607,15 +623,26 @@ export class WaveShaper {
     if (silent) return;
 
     if (data?.type !== undefined && reports.length > 0) {
-      for (const rect of reports) this.invalidateRect(rect);
+      for (const report of reports) {
+        this.#unionRegion(report.rect);
+        // display-only regions - a hover marker - repaint without forcing
+        // the hit canvas to rebuild on the next probe
+        if (report.hitPixels) this.#hiddenDirty = true;
+      }
     } else {
       this.invalidate();
     }
   }
 
   /** Handed to renderers so they can report regions during a bind. */
-  #reportDirty = (x0: number, y0: number, x1: number, y1: number) => {
-    this.#bindReports?.push({ x0, y0, x1, y1 });
+  #reportDirty = (
+    x0: number,
+    y0: number,
+    x1: number,
+    y1: number,
+    hitPixels = true
+  ) => {
+    this.#bindReports?.push({ rect: { x0, y0, x1, y1 }, hitPixels });
   };
 
   /**
@@ -632,10 +659,19 @@ export class WaveShaper {
    */
   #panShift(deltaCss: number): boolean {
     const { width, height } = this.state.configuration;
-    const deltaDevice = Math.round(deltaCss * this.#dpr);
+
+    const total = deltaCss + this.#panResidual;
+    const deltaDevice = Math.round(total * this.#dpr);
+
+    if (Math.abs(deltaDevice) >= this.#width) {
+      this.#panResidual = 0;
+      return false;
+    }
+
+    // what the shift cannot show this tick is carried into the next one
+    this.#panResidual = total - deltaDevice / this.#dpr;
 
     if (deltaDevice === 0) return true;
-    if (Math.abs(deltaDevice) >= this.#width) return false;
 
     // Copy shifted into the spare buffer, then swap the pair - one copy
     // instead of copy-out-and-back, and no reliance on overlapping

--- a/src/renderers/automation.ts
+++ b/src/renderers/automation.ts
@@ -6,7 +6,6 @@ import type {
   AutomationPoint,
   Selection,
   BoundData,
-  DirtyRect,
   Predicate,
   Renderer,
   ReportDirtyFn,
@@ -54,6 +53,8 @@ export class AutomationRenderer implements Renderer {
   #filterFn: Predicate = ALWAYS;
   #hoverX: number | null = null;
   #hoverY: number | null = null;
+  /** Band height at the time the marker was placed, for erasing it later. */
+  #lastTrackHeight = 0;
   #selectedSet = new Set<string>();
   #selectedOffsets = new Map<
     string,
@@ -65,14 +66,6 @@ export class AutomationRenderer implements Renderer {
   #selectedTrack: string | null = null;
 
   TYPE = Symbol("automation");
-
-  /**
-   * Marker regions whose pixels the last hover change touched, waiting for
-   * the bind that the change requested. Reported as display-only: the
-   * marker never reaches the hit canvas, so repainting it must not force a
-   * hit rebuild on the next probe.
-   */
-  #pendingHoverRects: DirtyRect[] = [];
 
   constructor(
     private readonly canvas: HTMLCanvasElement,
@@ -261,6 +254,7 @@ export class AutomationRenderer implements Renderer {
       case TYPES.AUTOMATION_POINT: {
         this.#hoverX = d3.pointer(e, this.canvas)[0];
         this.#hoverY = yScale(d.data.track)!;
+        this.#lastTrackHeight = yScale.bandwidth();
         break;
       }
       default: {
@@ -273,29 +267,54 @@ export class AutomationRenderer implements Renderer {
 
     // The marker is baked into the draw buffer, so moving it needs a
     // repaint where it was and where it lands - without one, a partial
-    // paint elsewhere would strand the old marker on screen. The rects ride
-    // the bind this returns.
+    // paint elsewhere would strand the old marker on screen. Reported
+    // directly rather than through a bind: nothing about the lanes or
+    // points changed, so re-joining them per mousemove would be pure
+    // waste, and the render pass draws the marker from the fields set
+    // above. Display-only, since the marker never reaches the hit canvas.
     const trackHeight = yScale.bandwidth();
 
     if (previousX != null && previousY != null) {
-      this.#pendingHoverRects.push({
-        x0: previousX - 1,
-        y0: previousY - 1,
-        x1: previousX + 2,
-        y1: previousY + trackHeight + 1,
-      });
+      this.reportDirty(
+        previousX - 1,
+        previousY - 1,
+        previousX + 2,
+        previousY + trackHeight + 1,
+        false
+      );
     }
 
     if (this.#hoverX != null && this.#hoverY != null) {
-      this.#pendingHoverRects.push({
-        x0: this.#hoverX - 1,
-        y0: this.#hoverY - 1,
-        x1: this.#hoverX + 2,
-        y1: this.#hoverY + trackHeight + 1,
-      });
+      this.reportDirty(
+        this.#hoverX - 1,
+        this.#hoverY - 1,
+        this.#hoverX + 2,
+        this.#hoverY + trackHeight + 1,
+        false
+      );
     }
+  }
 
-    return { type: this.TYPE };
+  onZoom(e: d3.D3ZoomEvent<any, any>) {
+    // The marker is pointer-anchored but its pixels are baked into a buffer
+    // the pan fast path shifts, so a gesture would drag it across the
+    // screen - and a strip repaint could draw a second one. The pointer
+    // relationship is broken mid-gesture anyway: drop the marker, and
+    // report its strip before the shift so the blit carries the erase to
+    // wherever those pixels land.
+    if (e.sourceEvent == null) return;
+    if (this.#hoverX == null || this.#hoverY == null) return;
+
+    this.reportDirty(
+      this.#hoverX - 1,
+      this.#hoverY - 1,
+      this.#hoverX + 2,
+      this.#hoverY + this.#lastTrackHeight + 1,
+      false
+    );
+
+    this.#hoverX = null;
+    this.#hoverY = null;
   }
 
   onBind(
@@ -304,11 +323,6 @@ export class AutomationRenderer implements Renderer {
     xScale: ScaleLinear<number, number>,
     yScale: ScaleBand<string>
   ): void {
-    for (const rect of this.#pendingHoverRects) {
-      this.reportDirty(rect.x0, rect.y0, rect.x1, rect.y1, false);
-    }
-    this.#pendingHoverRects.length = 0;
-
     const trackHeight = yScale.bandwidth();
     const points = state.automationData.flatMap((d) =>
       d.points.map((p) => ({

--- a/src/renderers/automation.ts
+++ b/src/renderers/automation.ts
@@ -335,6 +335,13 @@ export class AutomationRenderer implements Renderer {
 
     const that = this;
 
+    // Tracks whose automation this bind touched. A lane's curve spans
+    // between its points, so any point change can move pixels anywhere
+    // along the band - the full-width band is the tight honest region, and
+    // reporting it is what keeps an automation edit from repainting every
+    // other track.
+    const touchedTracks = new Set<string>();
+
     selection
       .selectAll<LaneNode, AutomationData>(
         `custom.${TYPES.AUTOMATION.description}`
@@ -352,6 +359,7 @@ export class AutomationRenderer implements Renderer {
               };
 
               d.points.sort((a, b) => a.time - b.time);
+              touchedTracks.add(d.track);
             }),
         (update) =>
           update.filter(this.#filterFn).each(function (d) {
@@ -359,12 +367,14 @@ export class AutomationRenderer implements Renderer {
             if (lane !== undefined) lane.y = yScale(d.track)!;
 
             d.points.sort((a, b) => a.time - b.time);
+            touchedTracks.add(d.track);
           }),
         (remove) =>
           remove
-            .each(function () {
+            .each(function (d) {
               const lane = this.__waveShaperLane;
               if (lane !== undefined) that.releaseFn(lane.bind);
+              touchedTracks.add(d.track);
             })
             .remove()
       );
@@ -397,15 +407,30 @@ export class AutomationRenderer implements Renderer {
 
               point.x = xScale(d.point.time);
               point.y = yScale(d.track)! + (1 - d.point.value) * trackHeight;
+              touchedTracks.add(d.track);
             }),
         (remove) =>
           remove
-            .each(function () {
+            .each(function (d) {
               const point = this.__waveShaperPoint;
               if (point !== undefined) that.releaseFn(point.bind);
+              touchedTracks.add(d.track);
             })
             .remove()
       );
+
+    const pad = AUTOMATION_HANDLE_RADIUS + 1;
+    for (const track of touchedTracks) {
+      const y = yScale(track);
+      if (y === undefined) continue;
+
+      this.reportDirty(
+        0,
+        y - pad,
+        state.configuration.width,
+        y + trackHeight + pad
+      );
+    }
   }
 
   onRender(

--- a/src/renderers/automation.ts
+++ b/src/renderers/automation.ts
@@ -208,6 +208,11 @@ export class AutomationRenderer implements Renderer {
         }
         break;
       }
+      default:
+        // Not this renderer's drag: requesting a rebind anyway would force
+        // a re-layout of every lane on every tick of an interval drag - and
+        // because this renderer reports no regions, a full repaint too.
+        return;
     }
 
     return { type: this.TYPE };

--- a/src/renderers/automation.ts
+++ b/src/renderers/automation.ts
@@ -6,8 +6,10 @@ import type {
   AutomationPoint,
   Selection,
   BoundData,
+  DirtyRect,
   Predicate,
   Renderer,
+  ReportDirtyFn,
   UpdateFn,
   WaveShaperState,
 } from "../types";
@@ -64,12 +66,21 @@ export class AutomationRenderer implements Renderer {
 
   TYPE = Symbol("automation");
 
+  /**
+   * Marker regions whose pixels the last hover change touched, waiting for
+   * the bind that the change requested. Reported as display-only: the
+   * marker never reaches the hit canvas, so repainting it must not force a
+   * hit rebuild on the next probe.
+   */
+  #pendingHoverRects: DirtyRect[] = [];
+
   constructor(
     private readonly canvas: HTMLCanvasElement,
     private readonly bindFn: (data: unknown, type: symbol) => string,
     private readonly releaseFn: (color: string) => void,
     private readonly updateState: (fn: UpdateFn<WaveShaperState>) => void,
-    private readonly hasModifier: (e: ModifierEvent) => boolean
+    private readonly hasModifier: (e: ModifierEvent) => boolean,
+    private readonly reportDirty: ReportDirtyFn
   ) {}
 
   onSelectStart(
@@ -242,6 +253,9 @@ export class AutomationRenderer implements Renderer {
     xScale: ScaleLinear<number, number>,
     yScale: ScaleBand<string>
   ) {
+    const previousX = this.#hoverX;
+    const previousY = this.#hoverY;
+
     switch (d?.type) {
       case TYPES.AUTOMATION:
       case TYPES.AUTOMATION_POINT: {
@@ -254,6 +268,34 @@ export class AutomationRenderer implements Renderer {
         this.#hoverY = null;
       }
     }
+
+    if (this.#hoverX === previousX && this.#hoverY === previousY) return;
+
+    // The marker is baked into the draw buffer, so moving it needs a
+    // repaint where it was and where it lands - without one, a partial
+    // paint elsewhere would strand the old marker on screen. The rects ride
+    // the bind this returns.
+    const trackHeight = yScale.bandwidth();
+
+    if (previousX != null && previousY != null) {
+      this.#pendingHoverRects.push({
+        x0: previousX - 1,
+        y0: previousY - 1,
+        x1: previousX + 2,
+        y1: previousY + trackHeight + 1,
+      });
+    }
+
+    if (this.#hoverX != null && this.#hoverY != null) {
+      this.#pendingHoverRects.push({
+        x0: this.#hoverX - 1,
+        y0: this.#hoverY - 1,
+        x1: this.#hoverX + 2,
+        y1: this.#hoverY + trackHeight + 1,
+      });
+    }
+
+    return { type: this.TYPE };
   }
 
   onBind(
@@ -262,6 +304,11 @@ export class AutomationRenderer implements Renderer {
     xScale: ScaleLinear<number, number>,
     yScale: ScaleBand<string>
   ): void {
+    for (const rect of this.#pendingHoverRects) {
+      this.reportDirty(rect.x0, rect.y0, rect.x1, rect.y1, false);
+    }
+    this.#pendingHoverRects.length = 0;
+
     const trackHeight = yScale.bandwidth();
     const points = state.automationData.flatMap((d) =>
       d.points.map((p) => ({

--- a/src/renderers/interval.ts
+++ b/src/renderers/interval.ts
@@ -260,8 +260,13 @@ export class IntervalRenderer implements Renderer {
 
     const audioData = this.#getAudioData(state, interval.data);
 
+    // A hidden waveform needs no summary either - with the flag off the
+    // interval layer does no per-sample work at all. The render flag is
+    // checked here too so toggling it back on recomputes on the next bind.
+    const hidden = state.configuration.showWaveform === false;
+
     // Interval is not in viewport, render nothing
-    if (intervalScreenDuration <= 0 || audioData === undefined) {
+    if (hidden || intervalScreenDuration <= 0 || audioData === undefined) {
       this.#drawDataCache.delete(interval.id);
     } else {
       this.#drawDataCache.set(
@@ -454,7 +459,7 @@ export class IntervalRenderer implements Renderer {
         context.fillRect(x, y, width, height);
 
         // audio waveform, not interactive so only render to display canvas
-        if (toHidden === false) {
+        if (toHidden === false && state.configuration.showWaveform !== false) {
           const data = that.#drawDataCache.get(d.id);
           if (data !== undefined) {
             renderWave(

--- a/src/renderers/interval.ts
+++ b/src/renderers/interval.ts
@@ -7,6 +7,8 @@ import type {
   BoundData,
   Predicate,
   AudioData,
+  DirtyRect,
+  ReportDirtyFn,
 } from "../types";
 import {
   ALWAYS,
@@ -94,8 +96,25 @@ export class IntervalRenderer implements Renderer {
     private readonly hasModifier: (e: ModifierEvent) => boolean,
     /** Device pixels per CSS pixel, read fresh so a resize is picked up. */
     private readonly getPixelRatio: () => number,
-    private readonly sampleRate: number
+    private readonly sampleRate: number,
+    private readonly reportDirty: ReportDirtyFn
   ) {}
+
+  /**
+   * Report the screen region an interval's layout occupies, padded for the
+   * fade handles that poke above the top edge and a pixel of antialiasing.
+   * Reporting every changed layout is what lets a filtered bind - one
+   * dragged interval - repaint only the pixels it actually touched.
+   */
+  #reportLayout(layout: IntervalLayout) {
+    const margin = RESIZE_HANDLE_WIDTH + 1;
+    this.reportDirty(
+      layout.x - margin,
+      layout.y - margin,
+      layout.x + layout.width + margin,
+      layout.y + layout.height + margin
+    );
+  }
 
   onStateUpdate(state: WaveShaperState) {
     this.#colorMap.clear();
@@ -139,6 +158,11 @@ export class IntervalRenderer implements Renderer {
         fadeOut(e, d.data, xScale);
         break;
       }
+      default:
+        // Not this renderer's drag: requesting a rebind anyway would force
+        // a re-layout of every interval on every tick of, say, an
+        // automation point drag - and a repaint to go with it.
+        return;
     }
 
     return this.#bindFilter;
@@ -328,6 +352,7 @@ export class IntervalRenderer implements Renderer {
                 fadeOut: that.bindFn(d, TYPES.FADE_OUT),
               });
 
+              that.#reportLayout(this.__waveShaperLayout);
               that.summarizeAudio(d, state, xScale);
             }),
         (update) => {
@@ -345,6 +370,10 @@ export class IntervalRenderer implements Renderer {
               previous.bind
             );
 
+            // both where the element was and where it is now need repainting
+            that.#reportLayout(previous);
+            that.#reportLayout(this.__waveShaperLayout);
+
             that.summarizeAudio(d, state, xScale);
           });
 
@@ -357,7 +386,10 @@ export class IntervalRenderer implements Renderer {
               // grows for the lifetime of the page.
               that.clearAudioCache(d.id);
 
-              const bind = this.__waveShaperLayout?.bind;
+              const layout = this.__waveShaperLayout;
+              if (layout !== undefined) that.#reportLayout(layout);
+
+              const bind = layout?.bind;
               if (bind === undefined) return;
 
               that.releaseFn(bind.interval);
@@ -377,7 +409,8 @@ export class IntervalRenderer implements Renderer {
     toHidden: boolean,
     xScale: d3.ScaleLinear<number, number, never>,
     yScale: d3.ScaleBand<string>,
-    state: WaveShaperState
+    state: WaveShaperState,
+    clip?: DirtyRect
   ) {
     const that = this;
     return selection
@@ -385,6 +418,20 @@ export class IntervalRenderer implements Renderer {
       .each(function (d) {
         const layout = this.__waveShaperLayout;
         if (layout === undefined) return;
+
+        // The context is clipped to the repaint region, so skipping an
+        // element entirely outside it changes nothing on screen - it only
+        // saves building the element's draw calls, of which the waveform
+        // path is the expensive one.
+        if (
+          clip !== undefined &&
+          (layout.x + layout.width + RESIZE_HANDLE_WIDTH < clip.x0 ||
+            layout.x - RESIZE_HANDLE_WIDTH > clip.x1 ||
+            layout.y + layout.height + RESIZE_HANDLE_WIDTH < clip.y0 ||
+            layout.y - RESIZE_HANDLE_WIDTH > clip.y1)
+        ) {
+          return;
+        }
 
         const bind = layout.bind;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,6 +89,14 @@ export type WaveShaperConfig = {
    * tracks are on screen at once.
    */
   showRmsBand: boolean;
+
+  /**
+   * Debugging aid: tint the region each paint actually repainted, on the
+   * visible canvas only. Paints happen on change, so a tint stays up until
+   * the next one - a drag should flash just the dragged clip, a pan just
+   * the strip its blit exposed, and a zoom or settle the whole area.
+   */
+  showPaintRegions?: boolean;
 };
 
 export type DragFn<TItem> = (

--- a/src/types.ts
+++ b/src/types.ts
@@ -91,6 +91,15 @@ export type WaveShaperConfig = {
   showRmsBand: boolean;
 
   /**
+   * Skip rendering waveforms entirely - intervals draw as plain colored
+   * blocks with their handles. This also skips computing the summaries the
+   * waveforms would need, so it is the cheapest the interval layer gets;
+   * worth having when a session grows past what a machine keeps up with.
+   * Undefined means on.
+   */
+  showWaveform?: boolean;
+
+  /**
    * Debugging aid: tint the region each paint actually repainted, on the
    * visible canvas only. Paints happen on change, so a tint stays up until
    * the next one - a drag should flash just the dragged clip, a pan just

--- a/src/types.ts
+++ b/src/types.ts
@@ -166,12 +166,16 @@ export interface DirtyRect {
  * change of a type-filtered bind is reported, only those regions repaint;
  * a bind with no reports falls back to repainting everything, so renderers
  * that never call this stay correct.
+ *
+ * Pass hitPixels false when the change is display-only - a hover marker,
+ * say - so it does not force the hit canvas to rebuild on the next probe.
  */
 export type ReportDirtyFn = (
   x0: number,
   y0: number,
   x1: number,
-  y1: number
+  y1: number,
+  hitPixels?: boolean
 ) => void;
 
 export type Renderer = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,6 +136,27 @@ export interface BindData {
   type: symbol;
 }
 
+/** An axis-aligned region of the render area, in CSS pixels. */
+export interface DirtyRect {
+  x0: number;
+  y0: number;
+  x1: number;
+  y1: number;
+}
+
+/**
+ * Reports a region whose pixels a renderer changed during a bind. When every
+ * change of a type-filtered bind is reported, only those regions repaint;
+ * a bind with no reports falls back to repainting everything, so renderers
+ * that never call this stay correct.
+ */
+export type ReportDirtyFn = (
+  x0: number,
+  y0: number,
+  x1: number,
+  y1: number
+) => void;
+
 export type Renderer = {
   TYPE: symbol;
 
@@ -152,7 +173,14 @@ export type Renderer = {
     toHidden: boolean,
     xScale: d3.ScaleLinear<number, number>,
     yScale: d3.ScaleBand<string>,
-    state: WaveShaperState
+    state: WaveShaperState,
+    /**
+     * Region being repainted, when it is less than the whole render area.
+     * The context is already clipped to it, so this is purely an
+     * optimization hint: elements entirely outside can be skipped without
+     * building their draw calls at all.
+     */
+    clip?: DirtyRect
   ) => void;
 
   onStateUpdate?: (state: WaveShaperState) => void;


### PR DESCRIPTION
Builds on #6 (now merged — rebased onto `main`). The display pipeline repainted every pixel for any change; painting is now region-scoped end to end, with the full repaint kept as the safe fallback everywhere.

## Dirty regions

- The boolean dirty flag becomes a **dirty region** (union rect, CSS px, snapped outward to device pixels so clears, clips and blits cut on the same texel boundaries). `redraw()` clears, clips and renders only inside it; pixels outside keep what they have. The visible canvas still receives one full-surface `drawImage` — after a pan blit every pixel has moved anyway, and it's a single copy either way.
- Every bind runs through a wrapper that collects **renderer-reported regions**. A type-filtered bind whose renderer reported every layout it changed repaints only those regions; an unfiltered bind, or a renderer that reports nothing, falls back to the full repaint. The collector nests, since `updateState` can run inside a bind handler. Reports made **outside** a bind (a hover moving, an async result landing) take effect on the dirty region directly instead of being dropped, and can be flagged display-only so they don't force a hit-canvas rebuild.
- The **interval renderer reports old + new bounds** for every layout it recomputes: dragging a clip repaints the clip. The **automation renderer reports the touched track's full-width band** — a lane's curve spans between its points, so the band is the tight honest region — meaning point drags and added points no longer repaint other tracks. The **hover marker** reports its own two thin strips straight from `onMouseOver` with no bind at all (nothing about the lanes changed), and is dropped at gesture start so the pan blit can't smear it.
- `onRender` receives the clip rect and skips elements entirely outside it.

## Pan blit

A zoom gesture that only translates shifts the draw buffer sideways by a **whole number of device pixels** — the same grid trick `AudioSummaryCache` uses, one level up — via a spare-buffer swap, and repaints just the exposed strip. The **sub-pixel remainder carries across ticks** (discarding it froze the canvas outright on devices that pan in fractional steps) and is absorbed by any full repaint, keeping the shifted canvas within half a device pixel of the true view; the gesture-end refine from #6 settles it exactly. A pending dirty region is carried along with the shift, or two pan ticks inside one frame would strand the first tick's strip.

## Cross-renderer drag fix

Both `onDrag` handlers returned their bind data unconditionally, so every interval drag tick also forced a re-layout of every automation lane and vice versa — pre-existing wasted work that region tracking turned into full repaints. Each renderer now requests a rebind only for drags it actually handled.

## Settled-state contract

A settled canvas must be indistinguishable from a from-scratch render. The review process surfaced that this cannot be *bit*-exact: Chromium rasterizes a fill slightly differently when a clip cuts through its path — deterministic (repainting the same region twice is bit-identical), but a few antialiasing units off a from-scratch render on scattered pixels (measured: ≤8 of 255 on ~0.006% of subpixels). The equality tests bound the comparison (max delta 16, ≤0.1% of subpixels), which still fails loudly on real staleness — a stranded marker or missed strip is full-contrast deltas over contiguous pixels.

## New config flags

- **`showPaintRegions`** (debug): tints and outlines each paint's region on the visible canvas, after the blit, persisting until the next paint.
- **`showWaveform`** (default on): off draws intervals as plain colored blocks and skips computing their summaries entirely — the interval layer's cost floor.

Both have demo checkboxes.

## Numbers

Demo padded to 11 intervals, real pointer gestures, headless Chromium (ratios are the signal):

| | redraw per pan tick | worst tick |
|---|---|---|
| base (#6) | ~3.7ms | 8–12ms |
| this PR | **~0.7ms** | ~1ms |

Zoom redraw is unchanged — zooming genuinely changes every pixel and keeps the full path.

## Tests

46 passing. `e2e/partial-redraw.test.ts` pins: settled drag/pan/automation-drag vs full repaint (bounded as above); partial paints actually partial via the `lastPaintFraction` diagnostic (interval drag < 0.5, automation drag < 0.5, mid-pan < 0.1); gesture-end refine repaints everything; sub-pixel pan deltas keep moving the canvas mid-gesture; moving the hover marker leaves nothing behind; `showPaintRegions` tints exactly the dragged region and vanishes when off; `showWaveform` off drops the waveform, holds zero summary buckets, and restores identical pixels. All visual snapshots pass unchanged.