### PR TITLE
Build waveform pyramids in a worker, off the first paint

### DIFF
--- a/e2e/audio.test.ts
+++ b/e2e/audio.test.ts
@@ -37,6 +37,7 @@ test.describe("summarizeAudio", () => {
 
         const data = new Float32Array(sampleRate * 10);
         for (let i = 0; i < data.length; i++) data[i] = Math.sin(i / 50) * 0.8;
+        await cache.prepare(data);
 
         let refKey = 0;
         let worst = 0;
@@ -79,6 +80,7 @@ test.describe("summarizeAudio", () => {
 
         const data = new Float32Array(sampleRate * 10);
         for (let i = 0; i < data.length; i++) data[i] = Math.sin(i / 37) * 0.7;
+        await cache.prepare(data);
 
         const windows = [
           [1000, 2000], [1000, 2500], [1000, 1800], [900, 2600],
@@ -122,6 +124,7 @@ test.describe("summarizeAudio", () => {
 
         const data = new Float32Array(sampleRate * 10);
         for (let i = 0; i < data.length; i++) data[i] = Math.sin(i / 50) * 0.8;
+        await cache.prepare(data);
 
         summarizeAudio(data, "zoomed", 1000, 2000, 512, sampleRate);
         const cached = summarizeAudio(data, "zoomed", 1000, 2000, 256, sampleRate);
@@ -155,7 +158,7 @@ test.describe("summarizeAudio", () => {
         const summarizeAudio = cache.summarize.bind(cache);
         const { DRAW_STRIDE } = await import(url);
 
-        const measure = (sampleRate: number) => {
+        const measure = async (sampleRate: number) => {
           const data = new Float32Array(sampleRate * 2);
           for (
             let i = Math.round(0.5 * sampleRate);
@@ -164,6 +167,7 @@ test.describe("summarizeAudio", () => {
           ) {
             data[i] = 0.9;
           }
+          await cache.prepare(data);
 
           // 10ms per pixel, so the burst belongs in pixels 50..59
           const spp = sampleRate / 100;
@@ -183,7 +187,7 @@ test.describe("summarizeAudio", () => {
           return { first, last, width: summary.length / DRAW_STRIDE };
         };
 
-        return { at44100: measure(44100), at48000: measure(48000) };
+        return { at44100: await measure(44100), at48000: await measure(48000) };
       },
       { url: AUDIO_MODULE_URL }
     );
@@ -205,6 +209,7 @@ test.describe("summarizeAudio", () => {
         const { DRAW_STRIDE } = await import(url);
 
         const data = new Float32Array(sampleRate).fill(0.5); // exactly 1000ms
+        await cache.prepare(data);
         // window runs 200ms past the end of the audio
         const summary = summarizeAudio(data, "tail", 800, 400, 512, sampleRate);
 
@@ -242,6 +247,7 @@ test.describe("summarizeAudio", () => {
         for (let i = 0; i < data.length; i++) {
           data[i] = i % spp < 30 ? 0.95 : 0.1 * Math.sin(i / 20);
         }
+        await cache.prepare(data);
 
         const summary = summarizeAudio(data, "peaks", 200, 500, spp, sampleRate);
         const offset = 10 * DRAW_STRIDE;
@@ -271,9 +277,10 @@ test.describe("summarizeAudio", () => {
         const summarizeAudio = cache.summarize.bind(cache);
         const { DRAW_STRIDE } = await import(url);
 
-        const measure = (label: string, positive: (i: number) => boolean) => {
+        const measure = async (label: string, positive: (i: number) => boolean) => {
           const data = new Float32Array(sampleRate);
           for (let i = 0; i < data.length; i++) data[i] = positive(i) ? 1 : -1;
+          await cache.prepare(data);
 
           const summary = summarizeAudio(data, label, 200, 500, 441, sampleRate);
           const offset = 10 * DRAW_STRIDE;
@@ -282,8 +289,8 @@ test.describe("summarizeAudio", () => {
         };
 
         return {
-          mostlyPositive: measure("dutyHigh", (i) => i % 10 !== 0),
-          mostlyNegative: measure("dutyLow", (i) => i % 10 === 0),
+          mostlyPositive: await measure("dutyHigh", (i) => i % 10 !== 0),
+          mostlyNegative: await measure("dutyLow", (i) => i % 10 === 0),
         };
       },
       { url: AUDIO_MODULE_URL, sampleRate: SAMPLE_RATE }
@@ -312,6 +319,7 @@ test.describe("summarizeAudio", () => {
               Math.sin(i / (3 + (shape % 17))) * (shape % 5) * 0.2;
           }
 
+          await cache.prepare(data);
           const summary = summarizeAudio(
             data, "shape" + shape, 100 + shape, 400, 200 + shape, sampleRate
           );
@@ -348,6 +356,7 @@ test.describe("summarizeAudio", () => {
 
         const data = new Float32Array(sampleRate * 2);
         for (let i = 0; i < data.length; i++) data[i] = Math.sin(i / 50) * 0.8;
+        await cache.prepare(data);
 
         summarizeAudio(data, "gone", 0, 500, 512, sampleRate);
         clearCachedData("gone");
@@ -395,6 +404,60 @@ test.describe("summarizeAudio", () => {
     expect(lengths).toEqual([0, 0, 0, 0]);
   });
 
+  test("returns a paintable summary before the pyramid lands", async ({
+    page,
+  }) => {
+    // Builds run in a worker, unawaited: the first summarize must hand back
+    // usable pixels immediately, report the build as pending, notify when it
+    // lands, and produce exact pixels from then on.
+    const result = await page.evaluate(
+      async ({ url, sampleRate }) => {
+        const { AudioSummaryCache } = await import(url);
+        const cache = new AudioSummaryCache();
+
+        const data = new Float32Array(sampleRate * 30);
+        for (let i = 0; i < data.length; i++) data[i] = Math.sin(i / 50) * 0.8;
+
+        let notified = false;
+        cache.onReady = () => {
+          notified = true;
+        };
+
+        const immediate = cache.summarize(data, "k", 0, 2000, 512, sampleRate);
+        const pendingAfterFirstCall =
+          cache.diagnostics().pyramidsPending > 0;
+
+        await cache.prepare(data);
+
+        const refined = cache.summarize(data, "k", 0, 2000, 512, sampleRate);
+
+        const reference = new AudioSummaryCache();
+        await reference.prepare(data);
+        const exact = reference.summarize(data, "x", 0, 2000, 512, sampleRate);
+
+        let worst = 0;
+        for (let i = 0; i < refined.length; i++) {
+          worst = Math.max(worst, Math.abs(refined[i] - exact[i]));
+        }
+
+        return {
+          immediateLength: immediate.length,
+          pendingAfterFirstCall,
+          notified,
+          pendingAfterPrepare: cache.diagnostics().pyramidsPending,
+          worst,
+        };
+      },
+      { url: AUDIO_MODULE_URL, sampleRate: SAMPLE_RATE }
+    );
+
+    expect(result.immediateLength).toBeGreaterThan(0);
+    expect(result.pendingAfterFirstCall).toBe(true);
+    expect(result.notified).toBe(true);
+    expect(result.pendingAfterPrepare).toBe(0);
+    expect(result.worst).toBe(0);
+  });
+
   test("keeps the outline solid below one sample per pixel", async ({
     page,
   }) => {
@@ -412,8 +475,10 @@ test.describe("summarizeAudio", () => {
           data[i] = 0.5 + Math.sin(i / 8) * 0.4;
         }
 
-        return [2, 1, 0.9, 0.5, 0.25, 0.1].map((spp) => {
+        const results = [];
+        for (const spp of [2, 1, 0.9, 0.5, 0.25, 0.1]) {
           const cache = new AudioSummaryCache();
+          await cache.prepare(data);
           const out = cache.summarize(data, "s" + spp, 0, 20, spp, sampleRate);
           const buckets = out.length / DRAW_STRIDE;
 
@@ -424,8 +489,9 @@ test.describe("summarizeAudio", () => {
             }
           }
 
-          return { spp, buckets, flat };
-        });
+          results.push({ spp, buckets, flat });
+        }
+        return results;
       },
       { url: AUDIO_MODULE_URL, sampleRate: SAMPLE_RATE }
     );
@@ -589,6 +655,13 @@ test.describe("waveform rendering", () => {
         state.configuration.showRmsBand = false;
         return [state, undefined, undefined];
       });
+      ws.process();
+
+      // the spike buffer's pyramid builds in a worker; measuring against
+      // the decimated fallback would miss the lone sample at wide zooms
+      while (ws.getDiagnostics().pyramidsPending > 0) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
       ws.process();
 
       const measure = () => {

--- a/e2e/utils.ts
+++ b/e2e/utils.ts
@@ -21,8 +21,30 @@ export async function loadPage(page: Page) {
 
   expect(canvas).not.toBeNull();
   await waitForRender(page);
+  await waitForExactWaveforms(page);
 
   return canvas;
+}
+
+/**
+ * Pyramids build in a worker while the first frames draw from decimated
+ * fallback summaries. Anything comparing pixels needs the refined state, so
+ * wait for the builds to land and the refine paint to flush.
+ */
+export async function waitForExactWaveforms(page: Page) {
+  await page.waitForFunction(
+    () =>
+      (globalThis as any)["WaveShaper"].getDiagnostics().pyramidsPending === 0
+  );
+
+  // the refine rebinds synchronously when the build lands, but the paint it
+  // asks for happens on the next animation frame
+  await page.evaluate(
+    () =>
+      new Promise((resolve) =>
+        requestAnimationFrame(() => requestAnimationFrame(resolve))
+      )
+  );
 }
 
 /**

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -13,6 +13,13 @@ const BASE_BUCKET = 64;
 const LEVEL_STRIDE = 3;
 
 /**
+ * Samples inspected per pixel by the approximate summarizer that fills in
+ * while a pyramid is still building - the decimated scan this library used
+ * for everything before pyramids existed.
+ */
+const FALLBACK_RESOLUTION = 128;
+
+/**
  * Pixels spanning at least this many samples are eligible for edge snapping
  * while a zoom gesture is in flight: edges land on the bucket grid, so folds
  * touch no raw samples at all. Snapping moves an edge by at most half a
@@ -67,6 +74,82 @@ export interface CacheData {
 const EMPTY: DrawData = new Float32Array(0);
 
 /**
+ * Build every pyramid level for one buffer.
+ *
+ * Deliberately self-contained - constants arrive as parameters and nothing
+ * from module scope is referenced - because its own source text doubles as
+ * the body of the build worker. A closure would stringify into code that
+ * throws inside the worker, so keep it free-standing.
+ */
+function buildLevels(
+  data: Float32Array,
+  baseBucket: number,
+  levelStride: number
+): Float64Array[] {
+  if (data.length === 0) return [];
+
+  const levels: Float64Array[] = [];
+  const baseCount = Math.ceil(data.length / baseBucket);
+  const base = new Float64Array(baseCount * levelStride);
+
+  for (let bucket = 0; bucket < baseCount; bucket++) {
+    const start = bucket * baseBucket;
+    const end = Math.min(start + baseBucket, data.length);
+
+    let min = Infinity;
+    let max = -Infinity;
+    let sumSquares = 0;
+
+    for (let i = start; i < end; i++) {
+      const val = data[i];
+      // Math.min/max compile to branchless float instructions; comparing
+      // and assigning branches instead, and audio crosses a running
+      // min/max unpredictably enough that those branches miss constantly.
+      min = Math.min(min, val);
+      max = Math.max(max, val);
+      sumSquares += val * val;
+    }
+
+    const offset = bucket * levelStride;
+    base[offset] = min;
+    base[offset + 1] = max;
+    base[offset + 2] = sumSquares;
+  }
+
+  levels.push(base);
+
+  let previous = base;
+  while (previous.length / levelStride > 1) {
+    const count = Math.ceil(previous.length / levelStride / 2);
+    const next = new Float64Array(count * levelStride);
+
+    for (let bucket = 0; bucket < count; bucket++) {
+      const left = bucket * 2 * levelStride;
+      const right = left + levelStride;
+      const offset = bucket * levelStride;
+
+      if (right < previous.length) {
+        next[offset] = Math.min(previous[left], previous[right]);
+        next[offset + 1] = Math.max(previous[left + 1], previous[right + 1]);
+        next[offset + 2] = previous[left + 2] + previous[right + 2];
+      } else {
+        // Odd tail: the parent covers only its left child's samples. It is
+        // only ever read for ranges that end inside the data, so the
+        // missing right half can never be asked for.
+        next[offset] = previous[left];
+        next[offset + 1] = previous[left + 1];
+        next[offset + 2] = previous[left + 2];
+      }
+    }
+
+    levels.push(next);
+    previous = next;
+  }
+
+  return levels;
+}
+
+/**
  * Multi-resolution summary of one audio buffer.
  *
  * Level k folds the buffer into buckets of BASE_BUCKET << k samples, each
@@ -81,68 +164,7 @@ const EMPTY: DrawData = new Float32Array(0);
  * point where accumulating in single precision visibly distorts the RMS.
  */
 class AudioPyramid {
-  readonly levels: Float64Array[] = [];
-
-  constructor(data: Float32Array) {
-    if (data.length === 0) return;
-
-    const baseCount = Math.ceil(data.length / BASE_BUCKET);
-    const base = new Float64Array(baseCount * LEVEL_STRIDE);
-
-    for (let bucket = 0; bucket < baseCount; bucket++) {
-      const start = bucket * BASE_BUCKET;
-      const end = Math.min(start + BASE_BUCKET, data.length);
-
-      let min = Infinity;
-      let max = -Infinity;
-      let sumSquares = 0;
-
-      for (let i = start; i < end; i++) {
-        const val = data[i];
-        // Math.min/max compile to branchless float instructions; comparing
-        // and assigning branches instead, and audio crosses a running
-        // min/max unpredictably enough that those branches miss constantly.
-        min = Math.min(min, val);
-        max = Math.max(max, val);
-        sumSquares += val * val;
-      }
-
-      const offset = bucket * LEVEL_STRIDE;
-      base[offset] = min;
-      base[offset + 1] = max;
-      base[offset + 2] = sumSquares;
-    }
-
-    this.levels.push(base);
-
-    let previous = base;
-    while (previous.length / LEVEL_STRIDE > 1) {
-      const count = Math.ceil(previous.length / LEVEL_STRIDE / 2);
-      const next = new Float64Array(count * LEVEL_STRIDE);
-
-      for (let bucket = 0; bucket < count; bucket++) {
-        const left = bucket * 2 * LEVEL_STRIDE;
-        const right = left + LEVEL_STRIDE;
-        const offset = bucket * LEVEL_STRIDE;
-
-        if (right < previous.length) {
-          next[offset] = Math.min(previous[left], previous[right]);
-          next[offset + 1] = Math.max(previous[left + 1], previous[right + 1]);
-          next[offset + 2] = previous[left + 2] + previous[right + 2];
-        } else {
-          // Odd tail: the parent covers only its left child's samples. It is
-          // only ever read for ranges that end inside the data, so the
-          // missing right half can never be asked for.
-          next[offset] = previous[left];
-          next[offset + 1] = previous[left + 1];
-          next[offset + 2] = previous[left + 2];
-        }
-      }
-
-      this.levels.push(next);
-      previous = next;
-    }
-  }
+  constructor(readonly levels: Float64Array[]) {}
 }
 
 /** Running fold of a sample range; reused across pixels to avoid allocation. */
@@ -155,9 +177,183 @@ type Fold = {
 /**
  * A pyramid is a pure function of its buffer, so unlike the pixel cache it is
  * safe to share across WaveShapers - and keyed weakly on the buffer, it goes
- * away with the audio without anyone having to say so.
+ * away with the audio without anyone having to say so. An entry with a null
+ * pyramid is one still being built; the waiters run when it lands.
  */
-const PYRAMIDS = new WeakMap<Float32Array, AudioPyramid>();
+type PyramidEntry = {
+  pyramid: AudioPyramid | null;
+  waiters: Set<() => void>;
+};
+
+const PYRAMIDS = new WeakMap<Float32Array, PyramidEntry>();
+
+/** Builds still in flight, module-wide; surfaced through diagnostics(). */
+let pendingBuilds = 0;
+
+/**
+ * The build worker is created from the build function's own source text, so
+ * there is no separate worker file for a bundler to know about. One worker
+ * serves every build; each request carries an id so responses find their
+ * entry no matter the order they land in.
+ */
+const WORKER_SOURCE = `"use strict";
+const buildLevels = ${buildLevels.toString()};
+self.onmessage = (e) => {
+  const { id, data, baseBucket, levelStride } = e.data;
+  const levels = buildLevels(data, baseBucket, levelStride);
+  self.postMessage({ id, levels }, levels.map((level) => level.buffer));
+};`;
+
+const inFlight = new Map<
+  number,
+  { data: Float32Array; resolve: (levels: Float64Array[] | null) => void }
+>();
+let nextBuildId = 0;
+
+/**
+ * Builds waiting for their turn at the worker. Jobs are handed over one at a
+ * time, each starting in its own task: handing a buffer to the worker costs
+ * a copy on this thread, and a burst of first summaries - a session loading
+ * twelve tracks - must not pay twelve copies before its first paint. The
+ * copy itself is a slice with the buffer transferred, which moves at memcpy
+ * speed instead of the structured-clone serializer's.
+ */
+const buildQueue: number[] = [];
+let postScheduled = false;
+
+function pumpBuildQueue() {
+  if (postScheduled || buildQueue.length === 0) return;
+  postScheduled = true;
+
+  setTimeout(() => {
+    postScheduled = false;
+
+    const id = buildQueue.shift();
+    if (id === undefined) return;
+
+    const job = inFlight.get(id);
+    const worker = getBuildWorker();
+
+    if (job === undefined) {
+      pumpBuildQueue();
+      return;
+    }
+
+    if (worker === null) {
+      // the worker died while this job queued; resolve on this thread
+      inFlight.delete(id);
+      job.resolve(null);
+      pumpBuildQueue();
+      return;
+    }
+
+    const copy = job.data.slice();
+    worker.postMessage(
+      { id, data: copy, baseBucket: BASE_BUCKET, levelStride: LEVEL_STRIDE },
+      [copy.buffer]
+    );
+  }, 0);
+}
+
+/** undefined = not tried yet, null = unavailable here. */
+let buildWorker: Worker | null | undefined;
+
+function getBuildWorker(): Worker | null {
+  if (buildWorker !== undefined) return buildWorker;
+
+  try {
+    const url = URL.createObjectURL(
+      new Blob([WORKER_SOURCE], { type: "text/javascript" })
+    );
+    // The worker holds its own reference to the script once constructed, so
+    // the URL can be released immediately.
+    buildWorker = new Worker(url);
+    URL.revokeObjectURL(url);
+
+    buildWorker.onmessage = (e: MessageEvent) => {
+      const job = inFlight.get(e.data.id);
+      inFlight.delete(e.data.id);
+      job?.resolve(e.data.levels);
+
+      // the next queued build gets its turn now that this one is done
+      pumpBuildQueue();
+    };
+
+    // A worker that dies mid-build would otherwise leave summaries
+    // approximate forever: finish its outstanding work here, and stop
+    // handing it new builds.
+    buildWorker.onerror = () => {
+      buildWorker?.terminate();
+      buildWorker = null;
+
+      const outstanding = [...inFlight.values()];
+      inFlight.clear();
+      buildQueue.length = 0;
+      outstanding.forEach((job) => job.resolve(null));
+    };
+  } catch {
+    buildWorker = null;
+  }
+
+  return buildWorker;
+}
+
+/**
+ * Hand back the pyramid for a buffer, or kick off its build and hand back
+ * null. The build runs in a worker when one is available - copying the
+ * buffer over costs a few milliseconds against ~20ms of build per three
+ * minutes of audio, and none of it blocks painting - and synchronously here
+ * when not. onReady fires once the pyramid lands; callers pass a stable
+ * function so waiting twice registers once.
+ */
+function requestPyramid(
+  data: Float32Array,
+  onReady: () => void
+): { pyramid: AudioPyramid | null; started: boolean } {
+  let entry = PYRAMIDS.get(data);
+  let started = false;
+
+  if (entry === undefined) {
+    entry = { pyramid: null, waiters: new Set() };
+    PYRAMIDS.set(data, entry);
+    started = true;
+
+    const worker = data.length > 0 ? getBuildWorker() : null;
+
+    if (worker === null) {
+      entry.pyramid = new AudioPyramid(
+        buildLevels(data, BASE_BUCKET, LEVEL_STRIDE)
+      );
+    } else {
+      const settled = entry;
+      const id = nextBuildId++;
+
+      pendingBuilds++;
+      inFlight.set(id, {
+        data,
+        resolve: (levels) => {
+          // levels is null when the worker died; rebuild here rather than
+          // staying approximate for the lifetime of the buffer
+          settled.pyramid = new AudioPyramid(
+            levels ?? buildLevels(data, BASE_BUCKET, LEVEL_STRIDE)
+          );
+          pendingBuilds--;
+
+          const waiters = [...settled.waiters];
+          settled.waiters.clear();
+          waiters.forEach((waiter) => waiter());
+        },
+      });
+
+      buildQueue.push(id);
+      pumpBuildQueue();
+    }
+  }
+
+  if (entry.pyramid === null) entry.waiters.add(onReady);
+
+  return { pyramid: entry.pyramid, started };
+}
 
 /**
  * Holds the per-key summaries for one WaveShaper.
@@ -171,6 +367,32 @@ export class AudioSummaryCache {
 
   /** Cumulative work counters, surfaced through diagnostics(). */
   #stats = { sampleReads: 0, bucketReads: 0, pyramidsBuilt: 0 };
+
+  /**
+   * Called when a pyramid this cache was waiting on lands. The owner should
+   * re-summarize and repaint: summaries produced before the pyramid existed
+   * are decimated approximations, flagged like snapped ones so any exact
+   * pass recomputes them.
+   */
+  onReady?: () => void;
+
+  /** Stable identity so waiting on several builds registers once each. */
+  #notifyReady = () => {
+    this.onReady?.();
+  };
+
+  /**
+   * Resolve when the pyramid for a buffer is ready, starting the build if
+   * nothing has yet. Rendering never needs this - it starts approximate and
+   * refines through onReady - but a caller that wants exact numbers from
+   * the first summarize, like a test, can await it.
+   */
+  prepare(data: Float32Array): Promise<void> {
+    return new Promise((resolve) => {
+      const { pyramid } = requestPyramid(data, resolve);
+      if (pyramid !== null) resolve();
+    });
+  }
 
   /**
    * Summarize the audio behind a time window into one min/max pair per pixel.
@@ -204,7 +426,7 @@ export class AudioSummaryCache {
 
     if (width <= 0) return EMPTY;
 
-    const { drawData, gaps, snapped } = this.#reuseCachedData(
+    let { drawData, gaps, snapped } = this.#reuseCachedData(
       cacheKey,
       startPixel,
       width,
@@ -217,18 +439,38 @@ export class AudioSummaryCache {
       const pyramid = this.#getPyramid(data);
 
       for (const [from, to] of gaps) {
-        summarizeRange(
-          data,
-          pyramid,
-          drawData,
-          startPixel,
-          from,
-          to,
-          spp,
-          snapped,
-          this.#stats
-        );
+        if (pyramid !== null) {
+          summarizeRange(
+            data,
+            pyramid,
+            drawData,
+            startPixel,
+            from,
+            to,
+            spp,
+            snapped,
+            this.#stats
+          );
+        } else {
+          // The pyramid is still building. Paint something now rather than
+          // block on it: a decimated scan, exactly the summarizer this
+          // library had before pyramids existed.
+          summarizeRangeApproximate(
+            data,
+            drawData,
+            startPixel,
+            from,
+            to,
+            spp,
+            this.#stats
+          );
+        }
       }
+
+      // Approximate pixels wear the snapped flag whatever was asked for, so
+      // the exact pass that follows onReady throws them away wholesale
+      // instead of trusting them.
+      if (pyramid === null) snapped = true;
     }
 
     this.#cache.set(cacheKey, {
@@ -265,16 +507,16 @@ export class AudioSummaryCache {
       summarySampleReads: this.#stats.sampleReads,
       summaryBucketReads: this.#stats.bucketReads,
       pyramidsBuilt: this.#stats.pyramidsBuilt,
+      // Anything above zero means summaries are still approximate and a
+      // refine will land shortly; at rest this must read 0.
+      pyramidsPending: pendingBuilds,
     };
   }
 
   #getPyramid(data: Float32Array) {
-    let pyramid = PYRAMIDS.get(data);
+    const { pyramid, started } = requestPyramid(data, this.#notifyReady);
 
-    if (pyramid === undefined) {
-      pyramid = new AudioPyramid(data);
-      PYRAMIDS.set(data, pyramid);
-
+    if (started) {
       this.#stats.pyramidsBuilt++;
       this.#stats.sampleReads += data.length;
     }
@@ -525,4 +767,73 @@ function foldRange(
   out.min = min;
   out.max = max;
   out.sumSquares = sumSquares;
+}
+
+/**
+ * Compute pixels [from, to) the way this library did before pyramids: every
+ * `skip`th sample, so a transient shorter than the decimation step can be
+ * missed. This only ever paints while a pyramid is still building - the
+ * summaries it produces are flagged for replacement, and the exact pass
+ * that follows the build's completion recomputes them from the pyramid.
+ */
+function summarizeRangeApproximate(
+  data: Float32Array,
+  drawData: DrawData,
+  startPixel: number,
+  from: number,
+  to: number,
+  spp: number,
+  stats: { sampleReads: number }
+) {
+  const skip = Math.max(1, Math.ceil(spp / FALLBACK_RESOLUTION));
+  const length = data.length;
+
+  for (let pixel = from; pixel < to; pixel++) {
+    const first = Math.round((startPixel + pixel) * spp);
+    const last = Math.round((startPixel + pixel + 1) * spp);
+
+    const start = Math.max(first, 0);
+    const end = Math.min(last, length);
+
+    let min = 0;
+    let max = 0;
+    let rms = 0;
+
+    if (end > start) {
+      let sumSquares = 0;
+      let count = 0;
+
+      for (let i = start; i < end; i += skip, count++) {
+        const val = data[i];
+        min = Math.min(min, val);
+        max = Math.max(max, val);
+        sumSquares += val * val;
+      }
+
+      rms = count > 0 ? Math.sqrt(sumSquares / count) : 0;
+      stats.sampleReads += count;
+    } else if (start < length) {
+      // Fewer than one sample per pixel; see summarizeRange, this is the
+      // same interpolated read.
+      const position = Math.max(0, (startPixel + pixel) * spp);
+      const index = Math.min(Math.floor(position), length - 1);
+      const next = Math.min(index + 1, length - 1);
+      const t = Math.min(1, Math.max(0, position - index));
+
+      const value = data[index] + (data[next] - data[index]) * t;
+
+      min = Math.min(0, value);
+      max = Math.max(0, value);
+      rms = Math.abs(value);
+
+      stats.sampleReads += 2;
+    }
+
+    const offset = pixel * DRAW_STRIDE;
+
+    drawData[offset] = min;
+    drawData[offset + 1] = max;
+    drawData[offset + 2] = Math.max(min, -rms);
+    drawData[offset + 3] = Math.min(max, rms);
+  }
 }

--- a/src/renderers/interval.ts
+++ b/src/renderers/interval.ts
@@ -95,7 +95,14 @@ export class IntervalRenderer implements Renderer {
     /** Device pixels per CSS pixel, read fresh so a resize is picked up. */
     private readonly getPixelRatio: () => number,
     private readonly sampleRate: number
-  ) {}
+  ) {
+    // Pyramids build off the main thread, so early paints draw from
+    // decimated fallback summaries. Those are flagged for replacement; the
+    // rebind here, once a pyramid lands, is what swaps in the exact ones.
+    this.#audioCache.onReady = () => {
+      this.updateState((state) => [state, this.#bindFilter, undefined]);
+    };
+  }
 
   onStateUpdate(state: WaveShaperState) {
     this.#colorMap.clear();


### PR DESCRIPTION
Closes out the follow-up noted in #6: the pyramid build ran synchronously on first summarize (~20ms per 3 minutes of audio), so a session loading a dozen tracks stalled its first paint by ~300ms.

## Design

Builds now run in a **worker, unawaited** — the same approximate-in-motion pattern the rest of the pipeline uses, applied to load:

- Until a buffer's pyramid lands, `summarize` paints from a **decimated fallback scan** (the exact summarizer this library used before pyramids existed, 128 samples/pixel). Those pixels wear the same flag snapped ones do, so no exact pass ever trusts them.
- When a build lands, the cache notifies its owner; the interval renderer answers with a rebind that swaps in exact summaries and repaints. **At rest with nothing pending, output is bit-identical to the synchronous version.**
- The worker is constructed from the build function's own source text via a Blob URL — `buildLevels` is deliberately closure-free so its stringified source runs in the worker — meaning **consumers' bundlers never need to know a worker exists**. If `Worker` construction throws (CSP, non-browser hosts) or the worker dies mid-build, everything falls back to building on the main thread, queued jobs included.
- Buffers are handed to the worker **one build at a time, each posted in its own task**, as a `slice()` with the buffer transferred. A burst of first summaries must not pay a dozen structured-clone serializations before its first frame — that alone was worth ~150ms in the benchmark — and slice-and-transfer moves at memcpy speed besides.

## Numbers

Twelve 2-minute tracks, first-bind burst, headless Chromium:

| | first paint blocked | fully exact after |
|---|---|---|
| main (sync build) | ~308ms | immediately |
| this PR | **~13-22ms** | ~0.5-1.3s later, off-thread |

## API surface

- `AudioSummaryCache.prepare(data): Promise<void>` — awaits pyramid readiness for callers that need exact numbers from the first call (the summary tests use it).
- `AudioSummaryCache.onReady` — invoked when a pyramid this cache waited on lands; the interval renderer wires it to a rebind.
- `getDiagnostics().pyramidsPending` — above zero means summaries are still approximate and a refine is coming; at rest it must read 0.

## Tests

37 passing (36 + 1 new). The new test pins the async contract: first summarize returns paintable pixels immediately, reports the build pending, notifies on completion, and produces bit-exact output afterward. Direct-summarize tests `await cache.prepare(data)`; `loadPage` waits for `pyramidsPending === 0` plus a frame so **all visual snapshots pass unchanged**. The transient-height test waits for its spike buffer's pyramid before measuring, since the decimated fallback can legitimately miss a lone sample.

Independent of #7 — based directly on `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sy5nkUPn9oGUKUpKANpxmd)_